### PR TITLE
Use SECURE_SSL_REDIRECT as the basis for other HTTPS-related setting defaults

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -221,11 +221,11 @@ SECURE_PROXY_SSL_HEADER = env(
     type_=(lambda v: tuple(v.split(":", 1)) if (v is not None and ":" in v) else None),
 )
 SECURE_SSL_REDIRECT = env("SECURE_SSL_REDIRECT", default=True, type_=boolish)
-SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", default=False, type_=boolish)
-CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=False, type_=boolish)
-SECURE_HSTS_SECONDS = env("SECURE_HSTS_SECONDS", default=0, type_=int)
+SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", default=SECURE_SSL_REDIRECT, type_=boolish)
+CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=SECURE_SSL_REDIRECT, type_=boolish)
+SECURE_HSTS_SECONDS = env("SECURE_HSTS_SECONDS", default=3600 if SECURE_SSL_REDIRECT else 0, type_=int)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env(
-    "SECURE_HSTS_INCLUDE_SUBDOMAINS", default=False, type_=boolish
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True, type_=boolish
 )
 SECURE_HSTS_PRELOAD = env("SECURE_HSTS_PRELOAD", default=False, type_=boolish)
 

--- a/{{cookiecutter.project_slug}}/config/settings/local.py
+++ b/{{cookiecutter.project_slug}}/config/settings/local.py
@@ -8,3 +8,6 @@ LOGGING["loggers"]["werkzeug"] = {
     "level": "DEBUG",
     "propagate": True,
 }
+
+# Make sure we default to no HSTS when running locally
+SECURE_HSTS_SECONDS = env("SECURE_HSTS_SECONDS", default=0, type_=int)


### PR DESCRIPTION
This keeps us more secure by default but keeps it easy to disable https when running locally.